### PR TITLE
fix: pad short timeBucket format for /timeline/bucket endpoint (#6)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -153,6 +153,12 @@ export async function validateToken(): Promise<boolean> {
 // within each bucket, so a whole section reads oldest-to-newest end to end.
 export type Order = 'asc' | 'desc';
 
+// Some Immich server versions return timeBucket in short form ("2026-07-01")
+// from /timeline/buckets, but /timeline/bucket expects the full ISO form
+// ("2026-07-01T00:00:00.000Z"). Normalise before sending the query back.
+const padBucket = (tb: string): string =>
+  tb.length === 10 ? tb + 'T00:00:00.000Z' : tb;
+
 // Default timeline query: own assets, exclude trashed. Order defaults to newest
 // first; callers pass the user's saved per-section direction.
 export async function getTimelineBuckets(order: Order = 'desc'): Promise<TimeBucket[]> {
@@ -165,7 +171,7 @@ export async function getBucket(
   order: Order = 'desc',
 ): Promise<BucketColumns> {
   const q = new URLSearchParams({
-    timeBucket,
+    timeBucket: padBucket(timeBucket),
     isTrashed: 'false',
     order,
   });
@@ -182,7 +188,7 @@ export async function getFavoriteBucket(
   order: Order = 'desc',
 ): Promise<BucketColumns> {
   const q = new URLSearchParams({
-    timeBucket,
+    timeBucket: padBucket(timeBucket),
     isTrashed: 'false',
     isFavorite: 'true',
     order,
@@ -220,7 +226,7 @@ export async function getAlbumBucket(
   timeBucket: string,
   order: Order = 'desc',
 ): Promise<BucketColumns> {
-  const q = new URLSearchParams({ albumId, timeBucket, order });
+  const q = new URLSearchParams({ albumId, timeBucket: padBucket(timeBucket), order });
   return jsonReq<BucketColumns>('/timeline/bucket?' + q.toString());
 }
 


### PR DESCRIPTION
/api/timeline/buckets returns timeBucket keys in the short YYYY-MM-DD form, but /api/timeline/bucket silently returns empty arrays unless the key is sent back as the full ISO-8601 timestamp
(YYYY-MM-DDT00:00:00.000Z).

This is a known Immich server quirk — the official web client hit the same issue and added equivalent normalisation:
  https://github.com/immich-app/immich/pull/20438

The same bug was also reported upstream and affects other third-party integrations:
  https://github.com/immich-app/immich/issues/22672
  https://github.com/xXRoxXeRXx/integration_immich/pull/53

Add a padBucket helper that appends T00:00:00.000Z when the key is exactly 10 characters, and apply it to getBucket, getFavoriteBucket, and getAlbumBucket — the three callers of /timeline/bucket.

Fixes #6