### PR TITLE
fix: run on webOS 4.x (Chromium 53) and tolerate Immich bucket format changes

### DIFF
--- a/src/api/assets.ts
+++ b/src/api/assets.ts
@@ -18,7 +18,45 @@ export interface Asset {
   isFavorite?: boolean; // weights the wallpaper shuffle toward favorites
 }
 
-export function flattenBucket(b: BucketColumns): Asset[] {
+// Pre-columnar Immich (and some proxies) answer /timeline/bucket with a plain
+// list of asset objects instead of parallel arrays. Normalise that shape into
+// BucketColumns so the columnar path below is the only one that matters.
+interface LegacyAsset {
+  id: string;
+  type?: string;
+  duration?: number | string | null;
+  fileCreatedAt?: string;
+  livePhotoVideoId?: string | null;
+  thumbhash?: string | null;
+  isFavorite?: boolean;
+  exifInfo?: { exifImageWidth?: number; exifImageHeight?: number };
+}
+
+function columnsFromList(list: LegacyAsset[]): BucketColumns {
+  const w = (a: LegacyAsset) => a.exifInfo?.exifImageWidth ?? 0;
+  const h = (a: LegacyAsset) => a.exifInfo?.exifImageHeight ?? 0;
+  return {
+    id: list.map((a) => a.id),
+    ratio: list.map((a) => (w(a) && h(a) ? w(a) / h(a) : 1)),
+    isImage: list.map((a) => a.type !== 'VIDEO'),
+    isFavorite: list.map((a) => !!a.isFavorite),
+    isTrashed: list.map(() => false),
+    duration: list.map((a) => a.duration ?? null),
+    livePhotoVideoId: list.map((a) => a.livePhotoVideoId ?? null),
+    fileCreatedAt: list.map((a) => a.fileCreatedAt ?? ''),
+    thumbhash: list.map((a) => a.thumbhash ?? null),
+  };
+}
+
+// Tolerant by design: the bucket payload has changed shape across Immich
+// releases, and a missing column here used to throw a TypeError that took out
+// the whole grid ("Failed to load bucket ..."). Every column is now optional
+// with a sane default, so an unfamiliar server degrades to fewer details
+// instead of an error screen.
+export function flattenBucket(raw: BucketColumns | LegacyAsset[] | null): Asset[] {
+  if (!raw) return [];
+  const b: BucketColumns = Array.isArray(raw) ? columnsFromList(raw) : raw;
+  if (!Array.isArray(b.id)) return [];
   const n = b.id.length;
   // Live Photos come back as two rows: the still (carrying livePhotoVideoId)
   // and its motion video. Immich's web hides the motion half; collect those
@@ -31,7 +69,8 @@ export function flattenBucket(b: BucketColumns): Asset[] {
   const out: Asset[] = [];
   for (let i = 0; i < n; i++) {
     if (motionIds.has(b.id[i])) continue;
-    const isImage = b.isImage[i];
+    // Absent isImage column: assume image unless a duration says otherwise.
+    const isImage = b.isImage ? b.isImage[i] : !b.duration?.[i];
     out.push({
       id: b.id[i],
       isImage,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -495,18 +495,44 @@ export interface AssetLocation {
   country?: string;
 }
 
-const locationCache = new Map<string, AssetLocation>();
+interface AssetInfo {
+  location: AssetLocation;
+  // EXIF orientation, normalised to 1 (upright) when absent or unparseable.
+  // Immich returns it as a string; anything other than 1 means the pixels are
+  // stored rotated or mirrored relative to how they should be displayed.
+  orientation: number;
+}
+
+const infoCache = new Map<string, AssetInfo>();
+
+async function getAssetInfo(id: string): Promise<AssetInfo> {
+  const hit = infoCache.get(id);
+  if (hit) return hit;
+  const a = await jsonReq<{
+    exifInfo?: { city?: string; state?: string; country?: string; orientation?: string | null };
+  }>(`/assets/${id}`);
+  const raw = parseInt(a.exifInfo?.orientation ?? '', 10);
+  const info: AssetInfo = {
+    location: {
+      city: a.exifInfo?.city ?? undefined,
+      state: a.exifInfo?.state ?? undefined,
+      country: a.exifInfo?.country ?? undefined,
+    },
+    // A tag we can't read is treated as rotated: displaying a correctly-
+    // oriented photo via the preview costs sharpness, showing a rotated one
+    // costs the shot.
+    orientation: a.exifInfo?.orientation == null ? 1 : isNaN(raw) ? 0 : raw,
+  };
+  infoCache.set(id, info);
+  return info;
+}
 
 export async function getAssetLocation(id: string): Promise<AssetLocation> {
-  if (locationCache.has(id)) return locationCache.get(id)!;
-  const a = await jsonReq<{ exifInfo?: { city?: string; state?: string; country?: string } }>(`/assets/${id}`);
-  const loc: AssetLocation = {
-    city: a.exifInfo?.city ?? undefined,
-    state: a.exifInfo?.state ?? undefined,
-    country: a.exifInfo?.country ?? undefined,
-  };
-  locationCache.set(id, loc);
-  return loc;
+  return (await getAssetInfo(id)).location;
+}
+
+export async function getAssetOrientation(id: string): Promise<number> {
+  return (await getAssetInfo(id)).orientation;
 }
 
 // Detected-face bounding box, normalized to 0..1 of the image. Immich reports

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -53,6 +53,28 @@ function base(): string {
   return getServer() + '/api';
 }
 
+// Build a query string by hand rather than via `new URLSearchParams(record)`.
+//
+// Older webOS ships a URLSearchParams whose constructor only understands a
+// query *string*: handed an object it stringifies it to "[object Object]" and
+// parses that, so every parameter silently disappears and the request goes out
+// bare. It fails quietly — endpoints whose parameters are all optional still
+// answer (/timeline/buckets returns the default timeline, which is why month
+// headers appear at all), so it only surfaces on a call with a required
+// parameter, as HTTP 400 "timeBucket: expected string, received undefined".
+//
+// encodeURIComponent has been universal since ES3, so this is safe everywhere.
+function qs(params: Record<string, string | undefined>): string {
+  const parts: string[] = [];
+  for (const key in params) {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) continue;
+    const value = params[key];
+    if (value === undefined || value === null) continue;
+    parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+  }
+  return parts.join('&');
+}
+
 function authHeaders(): Record<string, string> {
   return getAuthHeaders();
 }
@@ -78,6 +100,38 @@ export class ApiError extends Error {
     super(message);
     this.name = 'ApiError';
   }
+}
+
+// Turn whatever a failed call produced into one short line fit for a TV screen.
+// Immich has used two error envelopes: pre-v3 put validation failures in a
+// `message` array, v3 moved them to `errors: [{ path, message }]`. Unwrap both,
+// and fall back to the raw body for anything else (a reverse proxy's HTML 502,
+// say). Non-ApiError values are usually a TypeError from parsing an unexpected
+// payload — keep the name so that stays distinguishable from a server refusal.
+export function describeError(e: unknown): string {
+  if (e instanceof ApiError) {
+    let detail = e.message;
+    try {
+      const body = JSON.parse(e.message) as {
+        message?: string | string[];
+        errors?: { path?: string; message?: string }[];
+      };
+      if (body.errors?.length) {
+        detail = body.errors
+          .map((x) => (x.path ? x.path + ': ' + x.message : x.message))
+          .join('; ');
+      } else if (Array.isArray(body.message)) {
+        detail = body.message.join('; ');
+      } else if (body.message) {
+        detail = body.message;
+      }
+    } catch {
+      // not JSON — keep the raw body
+    }
+    return 'HTTP ' + e.status + ' — ' + detail.slice(0, 300);
+  }
+  if (e instanceof Error) return e.name + ': ' + e.message;
+  return String(e);
 }
 
 // --- Auth ---
@@ -153,47 +207,129 @@ export async function validateToken(): Promise<boolean> {
 // within each bucket, so a whole section reads oldest-to-newest end to end.
 export type Order = 'asc' | 'desc';
 
-// Some Immich server versions return timeBucket in short form ("2026-07-01")
-// from /timeline/buckets, but /timeline/bucket expects the full ISO form
-// ("2026-07-01T00:00:00.000Z"). Normalise before sending the query back.
-const padBucket = (tb: string): string =>
-  tb.length === 10 ? tb + 'T00:00:00.000Z' : tb;
+// --- Bucket key formats ---
+//
+// /timeline/buckets hands back a key that /timeline/bucket wants echoed back,
+// but which form is accepted has moved around across Immich releases:
+//
+//   'day' — "2026-07-01". What current servers return AND expect.
+//   'iso' — "2026-07-01T00:00:00.000Z". What some builds require instead; the
+//           official web client hit the same split (immich-app/immich#20438).
+//
+// Worse, a server that dislikes the form it was sent may either reject it
+// (400 "timeBucket must be a string") or silently answer 200 with empty
+// arrays — so we can't detect the mismatch from the status code alone.
+// Some servers also emit an unpadded key ("2026-8-1") that they then refuse
+// to accept back, so every form is zero-padded before it goes out.
+//
+// Rather than hardcode a guess, negotiate once per session: try the preferred
+// form, and if it 400s or comes back with zero assets, retry with the other
+// and remember whichever worked. See resolveBucket() below.
+type BucketFormat = 'day' | 'iso';
+
+const pad2 = (s: string): string => (s.length === 1 ? '0' + s : s);
+
+// "2026-8-1" / "2026-08-1" -> "2026-08-01". Anything that isn't a bare
+// year-month-day (already a full ISO timestamp, say) is passed through.
+function toDayKey(tb: string): string {
+  const m = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(tb);
+  return m ? m[1] + '-' + pad2(m[2]) + '-' + pad2(m[3]) : tb;
+}
+
+function toIsoKey(tb: string): string {
+  const day = toDayKey(tb);
+  return day.length === 10 ? day + 'T00:00:00.000Z' : day;
+}
+
+const formatKey = (tb: string, f: BucketFormat): string =>
+  f === 'iso' ? toIsoKey(tb) : toDayKey(tb);
+
+// Sticky once a form is known to work, so we pay the probe at most once —
+// but only for the server it was learned from, so pointing the app at a
+// different Immich re-probes instead of inheriting the wrong answer.
+let learned: { server: string; format: BucketFormat } | null = null;
+
+function knownFormat(): BucketFormat | null {
+  return learned && learned.server === getServer() ? learned.format : null;
+}
+
+function rememberFormat(format: BucketFormat): void {
+  learned = { server: getServer(), format };
+}
+
+const isEmptyBucket = (c: BucketColumns): boolean =>
+  !c || !Array.isArray(c.id) || c.id.length === 0;
+
+// Run `send` against each candidate form until one yields a non-empty bucket.
+// A bucket only exists because /timeline/buckets said it holds assets, so an
+// empty answer means the key was wrong, not that the month is empty.
+async function resolveBucket(
+  timeBucket: string,
+  send: (key: string) => Promise<BucketColumns>,
+): Promise<BucketColumns> {
+  const known = knownFormat();
+  const candidates: BucketFormat[] = known ? [known] : ['day', 'iso'];
+  let lastErr: unknown = null;
+  let lastEmpty: BucketColumns | null = null;
+
+  for (const f of candidates) {
+    try {
+      const cols = await send(formatKey(timeBucket, f));
+      if (!isEmptyBucket(cols)) {
+        rememberFormat(f);
+        return cols;
+      }
+      lastEmpty = cols;
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+
+  // Every form came back empty: genuinely nothing here (or a server we can't
+  // satisfy). Hand back the empty response rather than failing the section.
+  if (lastEmpty) return lastEmpty;
+  throw lastErr ?? new Error('bucket request failed');
+}
 
 // Default timeline query: own assets, exclude trashed. Order defaults to newest
 // first; callers pass the user's saved per-section direction.
 export async function getTimelineBuckets(order: Order = 'desc'): Promise<TimeBucket[]> {
-  const q = new URLSearchParams({ isTrashed: 'false', order });
-  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q.toString());
+  const q = qs({ isTrashed: 'false', order });
+  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q);
 }
 
 export async function getBucket(
   timeBucket: string,
   order: Order = 'desc',
 ): Promise<BucketColumns> {
-  const q = new URLSearchParams({
-    timeBucket: padBucket(timeBucket),
-    isTrashed: 'false',
-    order,
+  return resolveBucket(timeBucket, (key) => {
+    const q = qs({
+      timeBucket: key,
+      isTrashed: 'false',
+      order,
+    });
+    return jsonReq<BucketColumns>('/timeline/bucket?' + q);
   });
-  return jsonReq<BucketColumns>('/timeline/bucket?' + q.toString());
 }
 
 export async function getFavoriteBuckets(order: Order = 'desc'): Promise<TimeBucket[]> {
-  const q = new URLSearchParams({ isTrashed: 'false', isFavorite: 'true', order });
-  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q.toString());
+  const q = qs({ isTrashed: 'false', isFavorite: 'true', order });
+  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q);
 }
 
 export async function getFavoriteBucket(
   timeBucket: string,
   order: Order = 'desc',
 ): Promise<BucketColumns> {
-  const q = new URLSearchParams({
-    timeBucket: padBucket(timeBucket),
-    isTrashed: 'false',
-    isFavorite: 'true',
-    order,
+  return resolveBucket(timeBucket, (key) => {
+    const q = qs({
+      timeBucket: key,
+      isTrashed: 'false',
+      isFavorite: 'true',
+      order,
+    });
+    return jsonReq<BucketColumns>('/timeline/bucket?' + q);
   });
-  return jsonReq<BucketColumns>('/timeline/bucket?' + q.toString());
 }
 
 // --- Albums ---
@@ -217,8 +353,8 @@ export async function getAlbumBuckets(
   albumId: string,
   order: Order = 'desc',
 ): Promise<TimeBucket[]> {
-  const q = new URLSearchParams({ albumId, order });
-  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q.toString());
+  const q = qs({ albumId, order });
+  return jsonReq<TimeBucket[]>('/timeline/buckets?' + q);
 }
 
 export async function getAlbumBucket(
@@ -226,8 +362,10 @@ export async function getAlbumBucket(
   timeBucket: string,
   order: Order = 'desc',
 ): Promise<BucketColumns> {
-  const q = new URLSearchParams({ albumId, timeBucket: padBucket(timeBucket), order });
-  return jsonReq<BucketColumns>('/timeline/bucket?' + q.toString());
+  return resolveBucket(timeBucket, (key) => {
+    const q = qs({ albumId, timeBucket: key, order });
+    return jsonReq<BucketColumns>('/timeline/bucket?' + q);
+  });
 }
 
 // --- Search ---
@@ -424,11 +562,11 @@ export function originalUrl(id: string): string {
 
 // Direct streaming URL (token in query). Used as a plain <video src>.
 export function videoStreamUrl(id: string): string {
-  const q = new URLSearchParams(getAuthQuery());
-  return `${base()}/assets/${id}/video/playback?${q.toString()}`;
+  const q = qs(getAuthQuery());
+  return `${base()}/assets/${id}/video/playback?${q}`;
 }
 
 export function originalStreamUrl(id: string): string {
-  const q = new URLSearchParams(getAuthQuery());
-  return `${base()}/assets/${id}/original?${q.toString()}`;
+  const q = qs(getAuthQuery());
+  return `${base()}/assets/${id}/original?${q}`;
 }

--- a/src/api/internal-fetch.ts
+++ b/src/api/internal-fetch.ts
@@ -8,20 +8,46 @@ import { getAuthHeaders } from '../auth/store';
 // the whole grid stops loading (the network goes idle mid-scroll). So every
 // request is bounded by an AbortController timeout: on timeout the fetch aborts,
 // the promise rejects, and the slot is freed for the next asset.
-export async function authedBlobUrl(url: string, timeoutMs = 20000): Promise<string> {
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, {
-      headers: getAuthHeaders(),
-      signal: ctrl.signal,
-    });
-    if (!res.ok) throw new Error(`media ${res.status} for ${url}`);
+// AbortController is Chrome 66, and webOS 4.x TVs (the 2019 C9 reports
+// Chrome/53) don't have it — `new AbortController()` threw there, so every
+// thumbnail and video load failed and the grid rendered blank. The timeout is
+// what actually matters for the pool, so race the request against a timer and
+// only cancel for real where the API exists. Without it the socket is left to
+// finish on its own, but the promise still settles and the slot is freed.
+const canAbort = typeof AbortController !== 'undefined';
+
+export function authedBlobUrl(url: string, timeoutMs = 20000): Promise<string> {
+  const ctrl = canAbort ? new AbortController() : null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const load = (async () => {
+    const init: RequestInit = { headers: getAuthHeaders() };
     // Aborting also cancels an in-progress body read, so a stall during
     // .blob() (headers arrived, bytes never finish) is covered too.
+    if (ctrl) init.signal = ctrl.signal;
+    const res = await fetch(url, init);
+    if (!res.ok) throw new Error(`media ${res.status} for ${url}`);
     const blob = await res.blob();
     return URL.createObjectURL(blob);
-  } finally {
-    clearTimeout(timer);
-  }
+  })();
+
+  const expiry = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      if (ctrl) ctrl.abort();
+      reject(new Error(`media timeout after ${timeoutMs}ms for ${url}`));
+    }, timeoutMs);
+  });
+
+  // Two-arg then rather than .finally(): finally is itself polyfilled on these
+  // sets, and this path runs for every tile on screen.
+  return Promise.race([load, expiry]).then(
+    (v) => {
+      clearTimeout(timer);
+      return v;
+    },
+    (e) => {
+      clearTimeout(timer);
+      throw e;
+    },
+  );
 }

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -9,6 +9,25 @@
 import { authedBlobUrl } from './internal-fetch';
 import { thumbnailUrl, personThumbnailUrl } from './client';
 
+// Does the browser rotate an <img> to match its EXIF orientation tag?
+//
+// Chromium only started doing that by default in 81, which is also the version
+// that shipped the `image-orientation` property — so supporting the property is
+// a reliable proxy for the behaviour. webOS 4.x TVs run Chromium 53 and do
+// neither, which is why an original with an orientation tag renders as stored:
+// a portrait shot appears landscape, or upside down for orientation 3.
+//
+// Immich's re-encoded preview has the rotation baked into the pixels, so it is
+// always displayed correctly. Callers use this to decide when that trade
+// (correct but softer) is worth making.
+export const appliesExifOrientation: boolean = (() => {
+  try {
+    return typeof CSS !== 'undefined' && !!CSS.supports && CSS.supports('image-orientation', 'from-image');
+  } catch {
+    return false;
+  }
+})();
+
 // Sized to cover the ~6-page retention window (keepObserver) both directions so
 // scrolling back over recently-seen thumbs is a cache hit, never a refetch. Blobs
 // are small webp (~tens of KB); decoded bitmaps are freed when a Thumb drops its

--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from 'preact/hooks';
 import { memo } from 'preact/compat';
-import { TimeBucket, BucketColumns } from '../api/client';
+import { TimeBucket, BucketColumns, describeError } from '../api/client';
 import { Asset, flattenBucket } from '../api/assets';
 import { Thumb } from './Thumb';
 import { bucketObserver, setLazyRoot } from './lazyObserver';
@@ -113,7 +113,7 @@ export const PhotoGrid = memo(function PhotoGrid({ loadBuckets, loadBucket, onOp
       loadingRef.current.add(tb);
       loadBucket(tb)
         .then((cols) => setLoaded((m) => ({ ...m, [tb]: flattenBucket(cols) })))
-        .catch((e) => reportError(new Error(`Failed to load bucket ${tb}: ${e?.message ?? e}`)))
+        .catch((e) => reportError(new Error(`Failed to load bucket ${tb}: ${describeError(e)}`)))
         .finally(() => loadingRef.current.delete(tb));
     },
     [loadBucket],

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -2,6 +2,21 @@
 // 53) predate Promise.prototype.finally (Chrome 63). Vite's `target: chrome58`
 // only downlevels *syntax*, not runtime APIs, so the app boots straight into
 // "TypeError: ...finally is not a function" on those TVs. Add finally back.
+// String.prototype.padStart is Chrome 57. The 2019 C9 (OLED77C9PUB) reports
+// Chrome/53.0.2785.34, so formatting a video's duration badge threw a
+// TypeError there and took the surrounding grid down with it.
+if (typeof String !== 'undefined' && !String.prototype.padStart) {
+  // eslint-disable-next-line no-extend-native
+  String.prototype.padStart = function (targetLength: number, padString?: string): string {
+    const s = String(this);
+    const pad = padString === undefined ? ' ' : String(padString);
+    if (s.length >= targetLength || pad === '') return s;
+    let out = '';
+    while (out.length < targetLength - s.length) out += pad;
+    return out.slice(0, targetLength - s.length) + s;
+  };
+}
+
 if (typeof Promise !== 'undefined' && !Promise.prototype.finally) {
   // eslint-disable-next-line no-extend-native
   Promise.prototype.finally = function <T>(this: Promise<T>, onFinally?: (() => void) | null): Promise<T> {

--- a/src/views/WallpaperPlayer.tsx
+++ b/src/views/WallpaperPlayer.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from 'preact/hooks';
 import { createPortal } from 'preact/compat';
 import { Asset } from '../api/assets';
-import { loadBlobUrl, revoke } from '../api/media';
-import { thumbnailUrl, videoStreamUrl, originalUrl, getAssetLocation } from '../api/client';
+import { loadBlobUrl, revoke, appliesExifOrientation } from '../api/media';
+import { thumbnailUrl, videoStreamUrl, originalUrl, getAssetLocation, getAssetOrientation } from '../api/client';
 import { Key, isBack, dirFromKey } from '../nav/keys';
 import { fetchStations, Station } from '../api/radio';
 import { keepAwake } from '../api/screensaver';
@@ -269,7 +269,20 @@ export function WallpaperPlayer({ assets: assetsProp, mode, onExit, onNearEnd, o
       }
 
       try {
-        const src = await loadBlobUrl(originalUrl(a.id));
+        // On sets that don't auto-apply EXIF orientation (Chromium < 81, i.e.
+        // webOS 4.x), an original carrying an orientation tag paints rotated.
+        // Only those assets fall back to the preview, which Immich re-encodes
+        // upright — everything else keeps full original resolution. The lookup
+        // is free: /assets/{id} is already fetched and cached for the caption.
+        let bakeRotation = false;
+        if (!appliesExifOrientation) {
+          bakeRotation = await getAssetOrientation(a.id)
+            .then((o) => o !== 1)
+            .catch(() => false); // unreachable info: keep today's behaviour
+        }
+        const src = await loadBlobUrl(
+          bakeRotation ? thumbnailUrl(a.id, 'preview') : originalUrl(a.id),
+        );
         // Build and fully DECODE the actual <img> element before caching, then
         // reuse THAT element on screen (mounted via ref, like videos). A still
         // is "loaded" only once its real element can paint instantly. Decoding a


### PR DESCRIPTION
## Summary

Fixes the app on webOS 4.x TVs, where it currently fails at first load with
**"Failed to load bucket `<date>`"** / **"Something went wrong"**.

Diagnosed and confirmed fixed on an **LG OLED77C9PUB** (`core_os_release 4.9.7-17`),
which reports:

```
Chrome/53.0.2785.34
```

That's the crux: the README targets webOS 5.0+ (Chromium 68), but webOS 4.x is
**Chromium 53**, and three APIs the app relies on postdate it.

## Root cause

### 1. `URLSearchParams`' record constructor is Chrome 61 — this is the reported bug

Every timeline call built its query as `new URLSearchParams({ timeBucket, ... })`.
Chromium 53 only implements the *string* form, so it coerces the object via
`String()` to `"[object Object]"` and parses **that**. The request goes out as:

```
/api/timeline/bucket?%5Bobject+Object%5D=
```

Every parameter silently vanishes. It stays invisible wherever parameters are
optional — `/timeline/buckets` still returns the default timeline, which is why
**month headers render fine** — and only surfaces on `/timeline/bucket`, whose
`timeBucket` is required:

- Immich v3 (zod): `HTTP 400 — timeBucket: Invalid input: expected string, received undefined`
- Immich v2 (class-validator): `timeBucket must be a string`  ← the wording in #20

Query strings are now built with `encodeURIComponent`, which has been universal
since ES3. This also silently broke `albumId` on album timelines and the auth
token on direct video/original stream URLs.

### 2. `AbortController` is Chrome 66 — this is the blank-thumbnail bug

`authedBlobUrl()` gated **every** thumbnail and video load behind
`new AbortController()`, which throws on Chromium 53. That matches the reports in
#4 and #18 of "dates show but no photos".

The request is now raced against a timer and only aborted for real where the API
exists. What the media pool actually needs is for the promise to *settle* so the
slot is freed, and it now does either way.

### 3. `String.prototype.padStart` is Chrome 57

Used to format video duration badges. Polyfilled next to the existing
`Promise.prototype.finally` polyfill from aa772ba.

### 4. Slideshow stills ignored EXIF orientation

Chromium only auto-applies EXIF orientation to `<img>` from **81**. The wallpaper
player shows originals, which carry the raw tag, so on these sets a portrait shot
painted as landscape (orientation 6) or upside down (orientation 3). Grid
thumbnails were unaffected because Immich re-encodes them upright — which is why
it only showed up in the slideshow.

A CSS transform isn't workable here: `fitOnStage` sizes the image to 100%x100%
with `object-fit: cover`, so a 90° turn would rotate the stage-sized box rather
than the picture, and the face-aimed crop is computed against that box.

Instead, affected assets *only* fall back to Immich's `preview`, which is
re-encoded with the rotation baked into the pixels. Upright assets (the majority)
keep full original resolution, and sets that orient correctly never take the
fallback. The orientation comes from `/assets/{id}`, already fetched and cached
for the location caption, so this costs no extra requests.

## Also included: Immich bucket-format tolerance

Independent of webOS, `padBucket()` unconditionally appended `T00:00:00.000Z`.
Current servers return **and expect** the plain day form (`2026-08-01`), and a
mismatched key can answer `200` with empty arrays rather than an error — so it
can't be detected from the status code alone.

The format is now negotiated: try the day form, fall back to ISO on a failure or
an empty bucket, remember whichever worked (per server), and zero-pad short keys.

Two robustness fixes alongside it:

- **`flattenBucket` is now total.** It read `b.id.length` off whatever arrived, so
  an unexpected payload became a `TypeError` that took out the whole section.
  Every column is optional with a default, and a pre-columnar list-of-objects
  response is normalised rather than crashing.
- **Both Immich error envelopes are unwrapped** (pre-v3 `message` array, v3
  `errors` array) with the HTTP status included, so the on-screen message names
  the cause. This is what turned the original bare `TypeError` into the actionable
  400 above — it may be worth keeping just for future bug reports.

## Testing

- Confirmed working on the OLED77C9PUB: timeline, thumbnails, and slideshow.
- Query building verified against a faithful simulation of the Chromium 53
  `URLSearchParams` (constructor coercing via `String()`), asserting the old code
  reproduces `[object Object]` and the new code emits correct parameters.
- `flattenBucket` checked against real Immich v3.1 columnar payloads, legacy
  list-of-objects, partial column sets, and malformed/error bodies.
- Orientation normalisation checked for `"1"`, `"3"`, `"6"`, `"2"`, absent, `null`,
  and unparseable values, plus that the caption and orientation still share one
  cached request.
- `tsc --noEmit` clean; no dependency changes.

## Notes

- No version bump included — left to your `chore: release` flow.
- Likely closes #20, and plausibly #4 and #18 (both B8/C8, same signature), though
  I can only confirm the C9 directly.
- Untouched: `.album-grid` and `.places-grid` use `display: grid` (Chrome 57), so
  Albums and Places degrade to block layout on webOS 4.x. Cosmetic, and it felt
  out of scope here — happy to follow up with an `@supports` fallback if wanted.
- If you'd rather take this as two PRs (webOS compat vs. Immich bucket handling),
  the commits are already split that way and I can resubmit.
